### PR TITLE
Fixed apiVersion which was causing error while deploying metrics-server

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server


### PR DESCRIPTION
Error I recieved:  error: unable to recognize "metrics-server/deploy/1.8+/metrics-server-deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"